### PR TITLE
Cache sensor ranges on ICM20649

### DIFF
--- a/Adafruit_ICM20649.cpp
+++ b/Adafruit_ICM20649.cpp
@@ -42,8 +42,8 @@ bool Adafruit_ICM20649::begin_I2C(uint8_t i2c_address, TwoWire *wire,
 
 void Adafruit_ICM20649::scaleValues(void) {
 
-  icm20649_gyro_range_t gyro_range = getGyroRange();
-  icm20649_accel_range_t accel_range = getAccelRange();
+  icm20649_gyro_range_t gyro_range = current_gyro_range;
+  icm20649_accel_range_t accel_range = current_accel_range;
   float accel_scale = 1.0;
   float gyro_scale = 1.0;
 
@@ -93,6 +93,7 @@ icm20649_accel_range_t Adafruit_ICM20649::getAccelRange(void) {
 */
 void Adafruit_ICM20649::setAccelRange(icm20649_accel_range_t new_accel_range) {
   writeAccelRange((uint8_t)new_accel_range);
+  current_accel_range = new_accel_range;
 }
 
 /**************************************************************************/
@@ -114,4 +115,5 @@ icm20649_gyro_range_t Adafruit_ICM20649::getGyroRange(void) {
 */
 void Adafruit_ICM20649::setGyroRange(icm20649_gyro_range_t new_gyro_range) {
   writeGyroRange((uint8_t)new_gyro_range);
+  current_gyro_range = new_gyro_range;
 }

--- a/Adafruit_ICM20649.h
+++ b/Adafruit_ICM20649.h
@@ -57,6 +57,8 @@ public:
 
 private:
   void scaleValues(void);
+  icm20649_accel_range_t current_accel_range;
+  icm20649_gyro_range_t current_gyro_range;
 };
 
 #endif

--- a/Adafruit_ICM20948.cpp
+++ b/Adafruit_ICM20948.cpp
@@ -129,8 +129,8 @@ bool Adafruit_ICM20948::writeMagRegister(uint8_t mag_reg_addr, uint8_t value) {
 
 void Adafruit_ICM20948::scaleValues(void) {
 
-  icm20948_gyro_range_t gyro_range = getGyroRange();
-  icm20948_accel_range_t accel_range = getAccelRange();
+  icm20948_gyro_range_t gyro_range = current_gyro_range;
+  icm20948_accel_range_t accel_range = current_accel_range;
   float accel_scale = 1.0;
   float gyro_scale = 1.0;
 
@@ -184,6 +184,7 @@ icm20948_accel_range_t Adafruit_ICM20948::getAccelRange(void) {
 */
 void Adafruit_ICM20948::setAccelRange(icm20948_accel_range_t new_accel_range) {
   writeAccelRange((uint8_t)new_accel_range);
+  current_accel_range = new_accel_range;
 }
 
 /**************************************************************************/
@@ -205,6 +206,7 @@ icm20948_gyro_range_t Adafruit_ICM20948::getGyroRange(void) {
 */
 void Adafruit_ICM20948::setGyroRange(icm20948_gyro_range_t new_gyro_range) {
   writeGyroRange((uint8_t)new_gyro_range);
+  current_gyro_range = new_gyro_range;
 }
 
 /**

--- a/Adafruit_ICM20948.h
+++ b/Adafruit_ICM20948.h
@@ -98,6 +98,8 @@ private:
 
   bool setupMag(void);
   void scaleValues(void);
+  icm20948_accel_range_t current_accel_range;
+  icm20948_gyro_range_t current_gyro_range;
 };
 
 #endif


### PR DESCRIPTION
SPI reads for the ICM20649 using this library took about 94 ms on a Feather M0. I tracked this down to the retrieval of the gyro and accel ranges on each read operation. By stashing these variables away when they're set, we can reduce that read time to 15-20 ms. 

The only danger I can think of is if there is some code path that can get past sensor init without setting those ranges. I was unable to find such a path.

I don't have an ICM20948 to hand, so I was unable to test this fix on that part. It *should* work, but I don't know it for a fact, so I left that side unimplemented.