### PR TITLE
Fixed configureI2CMaster() return value

### DIFF
--- a/Adafruit_ICM20X.cpp
+++ b/Adafruit_ICM20X.cpp
@@ -700,7 +700,7 @@ bool Adafruit_ICM20X::configureI2CMaster(void) {
   Adafruit_BusIO_Register i2c_master_ctrl_reg = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, ICM20X_B3_I2C_MST_CTRL);
 
-  i2c_master_ctrl_reg.write(0x17);
+  return i2c_master_ctrl_reg.write(0x17);
 }
 
 /**************************************************************************/


### PR DESCRIPTION
The function for configureI2CMaster crashes the example code for using the sensor with I2C. It is supposed to return a bool so I modified the function to return result of the register write function. I tested with the example code in I2C configuration and it works well. SPI is unaffected because it doesn't use this function.