### PR TITLE
Fix warnings

### DIFF
--- a/Adafruit_ICM20649.h
+++ b/Adafruit_ICM20649.h
@@ -45,7 +45,7 @@ typedef enum {
 class Adafruit_ICM20649 : public Adafruit_ICM20X {
 public:
   Adafruit_ICM20649();
-  ~Adafruit_ICM20649(){};
+  virtual ~Adafruit_ICM20649(){};
   bool begin_I2C(uint8_t i2c_addr = ICM20649_I2CADDR_DEFAULT,
                  TwoWire *wire = &Wire, int32_t sensor_id = 0);
 

--- a/Adafruit_ICM20X.cpp
+++ b/Adafruit_ICM20X.cpp
@@ -76,9 +76,9 @@ Adafruit_ICM20X::~Adafruit_ICM20X(void) {
  */
 bool Adafruit_ICM20X::begin_I2C(uint8_t i2c_address, TwoWire *wire,
                                 int32_t sensor_id) {
-  (void) i2c_address;
-  (void) wire;
-  (void) sensor_id;
+  (void)i2c_address;
+  (void)wire;
+  (void)sensor_id;
   return false;
 }
 

--- a/Adafruit_ICM20X.cpp
+++ b/Adafruit_ICM20X.cpp
@@ -76,6 +76,9 @@ Adafruit_ICM20X::~Adafruit_ICM20X(void) {
  */
 bool Adafruit_ICM20X::begin_I2C(uint8_t i2c_address, TwoWire *wire,
                                 int32_t sensor_id) {
+  (void) i2c_address;
+  (void) wire;
+  (void) sensor_id;
   return false;
 }
 


### PR DESCRIPTION
Fix warnings from other repo ci log.

```
/home/runner/Arduino/libraries/Adafruit_Test_Library/Adafruit_SensorLab.cpp: In member function 'bool Adafruit_SensorLab::detectICM20649()':
/home/runner/Arduino/libraries/Adafruit_Test_Library/Adafruit_SensorLab.cpp:283:10: warning: deleting object of polymorphic class type 'Adafruit_ICM20649' which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
   delete _icm20649;
  
/home/runner/Arduino/libraries/Adafruit_ICM20X/Adafruit_ICM20X.cpp: In member function 'virtual bool Adafruit_ICM20X::begin_I2C(uint8_t, TwoWire*, int32_t)':
/home/runner/Arduino/libraries/Adafruit_ICM20X/Adafruit_ICM20X.cpp:77:41: warning: unused parameter 'i2c_address' [-Wunused-parameter]
 bool Adafruit_ICM20X::begin_I2C(uint8_t i2c_address, TwoWire *wire,
                                         ^~~~~~~~~~~
/home/runner/Arduino/libraries/Adafruit_ICM20X/Adafruit_ICM20X.cpp:77:63: warning: unused parameter 'wire' [-Wunused-parameter]
 bool Adafruit_ICM20X::begin_I2C(uint8_t i2c_address, TwoWire *wire,
                                                               ^~~~
/home/runner/Arduino/libraries/Adafruit_ICM20X/Adafruit_ICM20X.cpp:78:41: warning: unused parameter 'sensor_id' [-Wunused-parameter]
                                 int32_t sensor_id) {
                                         ^~~~~~~~~
```